### PR TITLE
Exynos 5422 patch

### DIFF
--- a/xen/arch/arm/platforms/exynos5.c
+++ b/xen/arch/arm/platforms/exynos5.c
@@ -165,8 +165,9 @@ static void exynos_cpu_power_up(void __iomem *power, int cpu)
 
 static int exynos5_cpu_power_up(void __iomem *power, int cpu)
 {
-    unsigned int timeout;
+    unsigned int timeout, val;
 
+    cpu = (cpu + 4) % 8; // logical mapping for EXYNOS5422 cores
     if ( !exynos_cpu_power_state(power, cpu) )
     {
         exynos_cpu_power_up(power, cpu);
@@ -187,6 +188,19 @@ static int exynos5_cpu_power_up(void __iomem *power, int cpu)
             return -ETIMEDOUT;
         }
     }
+
+    cpu = (cpu + 4) % 8; // logical mapping for EXYNOS5422 cores
+    if ( cpu < 4 )
+    {
+        while (!__raw_readl(power + EXYNOS5_PMU_SPARE2))
+            udelay(10);
+
+        udelay(10);
+
+        val = ((1 << 20) | (1 << 8)) << cpu;
+        __raw_writel(val, power + EXYNOS5_SWRESET);
+    }
+
     return 0;
 }
 
@@ -298,6 +312,7 @@ static const char * const exynos5250_dt_compat[] __initconst =
 static const char * const exynos5_dt_compat[] __initconst =
 {
     "samsung,exynos5410",
+    "samsung,exynos5422",
     NULL
 };
 

--- a/xen/arch/arm/traps.c
+++ b/xen/arch/arm/traps.c
@@ -47,6 +47,8 @@
 #include <asm/gic.h>
 #include <asm/vgic.h>
 
+#include <asm/processor.h>
+
 /* The base of the stack must always be double-word aligned, which means
  * that both the kernel half of struct cpu_user_regs (which is pushed in
  * entry.S) and struct cpu_info (which lives at the bottom of a Xen
@@ -2523,7 +2525,10 @@ asmlinkage void do_trap_hypervisor(struct cpu_user_regs *regs)
          */
         GUEST_BUG_ON(!psr_mode_is_32bit(regs->cpsr));
         perfc_incr(trap_smc32);
-        inject_undef32_exception(regs);
+	if (current->domain->domain_id == 0)
+		call_smc(regs->r0, regs->r1, regs->r2, regs->r3);
+	else
+		inject_undef32_exception(regs);
         break;
     case HSR_EC_HVC32:
         GUEST_BUG_ON(!psr_mode_is_32bit(regs->cpsr));

--- a/xen/common/sched_rt.c
+++ b/xen/common/sched_rt.c
@@ -1247,7 +1247,7 @@ rt_dom_cntl(
                           budget < MICROSECS(10) || budget > period )
             {
                 printk("RTDS: period (%ld) or budget (%ld) is invalid",
-                        period, budget);
+                        (long int) period, (long int) budget);
                 rc = -EINVAL;
                 break;
             }

--- a/xen/include/asm-arm/platforms/exynos5.h
+++ b/xen/include/asm-arm/platforms/exynos5.h
@@ -8,6 +8,7 @@
 #define EXYNOS5_PA_TIMER            0x12dd0000
 
 #define EXYNOS5_SWRESET             0x0400      /* Relative to PA_PMU */
+#define EXYNOS5_PMU_SPARE2          0x0908
 
 #endif /* __ASM_ARM_PLATFORMS_EXYNOS5_H */
 /*


### PR DESCRIPTION
applied https://github.com/bkrepo/xen/commit/8d56205455a4a1e0233421d3ee98e3c7dee20bd2 to RT-Xen and fixed a type cast error.

Used for the Odroid XU4 controller, exploring RT capabilities of XEN right now
